### PR TITLE
Fix TextArea.draw

### DIFF
--- a/examples/simple_gui_example.py
+++ b/examples/simple_gui_example.py
@@ -1,7 +1,7 @@
 
 
 
-import pgwidget_pkg.pgwidget.pgwidget_core as pgw
+import pgwidget.pgwidget_core as pgw
 
 
 import pygame

--- a/pgwidget/pgwidget_core.py
+++ b/pgwidget/pgwidget_core.py
@@ -1343,6 +1343,10 @@ class TextArea(TextContainerRect):
         engine.draw.rect(screen,self.border_color,[self.pos[0],self.pos[1],self.size[0],self.size[1]],1)
         self.label.pos = [self.pos[0]+2,self.pos[1]+4]
         self.blit_text(screen, self.label.text)
+
+        for label in self.labels:
+            if label.is_cursor_drawing:
+                label._draw_cursor(screen)
         #self.label.draw = self.blit_text
         #self.label.draw(screen, self.label.text)
 

--- a/pgwidget/pgwidget_core.py
+++ b/pgwidget/pgwidget_core.py
@@ -1339,8 +1339,9 @@ class TextArea(TextContainerRect):
                 break
         
     def draw(self,screen):
-        super().draw(screen)
+        # super().draw(screen)
         engine.draw.rect(screen,self.border_color,[self.pos[0],self.pos[1],self.size[0],self.size[1]],1)
+        self.label.pos = [self.pos[0]+2,self.pos[1]+4]
         self.blit_text(screen, self.label.text)
         #self.label.draw = self.blit_text
         #self.label.draw(screen, self.label.text)


### PR DESCRIPTION
-- blit text does not overlap now
-- implicitly removes "?" mark from "\n"